### PR TITLE
updated sea orm and improved migrations

### DIFF
--- a/mugen-server/Cargo.toml
+++ b/mugen-server/Cargo.toml
@@ -5,26 +5,26 @@ authors = ["koopa1338 <sinner1991@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-axum = "0.5.4"
+axum = "0.5.11"
 dotenv = "0.15.0"
-tokio = { version = "1.18.0", features = ["full"] }
-tokio-util = "0.7.1"
-tracing = "0.1.34"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json", "fmt", "registry"] }
-tracing-attributes = "0.1.21"
+tokio = { version = "1.19.2", features = ["full"] }
+tokio-util = "0.7.3"
+tracing = "0.1.35"
+tracing-subscriber = { version = "0.3.14", features = ["env-filter", "json", "fmt", "registry"] }
+tracing-attributes = "0.1.22"
 tracing-appender = "0.2.2"
-tower = { version = "0.4.12", features = ["timeout"] }
-tower-http = { version = "0.3.2", features = ["fs", "trace"] }
-serde = { version = "1.0.136", features = ["derive"] }
-sea-orm = { version = "0.7.1", features = [
+tower = { version = "0.4.13", features = ["timeout"] }
+tower-http = { version = "0.3.4", features = ["fs", "trace"] }
+serde = { version = "1.0.138", features = ["derive"] }
+sea-orm = { version = "0.8.0", features = [
     "sqlx-postgres",
     "runtime-tokio-native-tls",
     "macros",
     "with-json",
     "with-chrono",
 ], default-features = false }
-anyhow = "1.0.57"
-clap = { version = "3.1.13", features = ["derive", "env"] }
+anyhow = "1.0.58"
+clap = { version = "3.2.8", features = ["derive", "env"] }
 entity = { path = "entity" }
 migration = { path = "migration" }
 toml = "0.5.9"

--- a/mugen-server/entity/Cargo.toml
+++ b/mugen-server/entity/Cargo.toml
@@ -9,10 +9,10 @@ name = "entity"
 path = "src/lib.rs"
 
 [dependencies]
-serde = { version = "1.0.136", features = ["derive"] }
+serde = { version = "1.0.138", features = ["derive"] }
 
 [dependencies.sea-orm]
-version = "0.7.1"
+version = "0.8.0"
 features = [
   "macros",
   "debug-print",

--- a/mugen-server/migration/Cargo.toml
+++ b/mugen-server/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "migration"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 
@@ -9,5 +9,11 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-sea-schema = { version = "0.7.1", default-features = false, features = [ "migration", "debug-print" ] }
 entity = { path = "../entity" }
+sea-orm-migration = { version = "0.8.3", features = [ "runtime-tokio-native-tls", "sqlx-postgres" ] }
+sea-orm = { version = "0.8.0", features = [
+    "sqlx-postgres",
+    "runtime-tokio-native-tls",
+    "macros",
+], default-features = false }
+tokio = { version = "1.19.2", features = ["rt-multi-thread", "macros"] }

--- a/mugen-server/migration/src/lib.rs
+++ b/mugen-server/migration/src/lib.rs
@@ -1,4 +1,5 @@
-pub use sea_schema::migration::*;
+use sea_orm::DatabaseConnection;
+pub use sea_orm_migration::prelude::*;
 
 mod m20220214_000001_documents;
 
@@ -9,4 +10,7 @@ impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![Box::new(m20220214_000001_documents::Migration)]
     }
+}
+pub async fn migrate_database(connection: &DatabaseConnection) -> Result<(), DbErr> {
+    Migrator::up(connection, None).await
 }

--- a/mugen-server/migration/src/m20220214_000001_documents.rs
+++ b/mugen-server/migration/src/m20220214_000001_documents.rs
@@ -1,5 +1,5 @@
-use entity::document::*;
-use sea_schema::migration::prelude::*;
+use entity::{sea_orm::Schema, document::Entity as Document};
+pub use sea_orm_migration::prelude::*;
 
 pub struct Migration;
 
@@ -12,46 +12,17 @@ impl MigrationName for Migration {
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+
+        let builder = manager.get_database_backend();
+        let schema = Schema::new(builder);
         manager
-            .create_table(
-                sea_query::Table::create()
-                    .table(Entity)
-                    .if_not_exists()
-                    .col(
-                        ColumnDef::new(Column::Id)
-                            .big_integer()
-                            .not_null()
-                            .auto_increment()
-                            .primary_key(),
-                    )
-                    .col(ColumnDef::new(Column::Created).timestamp_with_time_zone())
-                    .col(ColumnDef::new(Column::LastUpdated).timestamp_with_time_zone())
-                    .col(
-                        ColumnDef::new(Column::Filetype)
-                            .string()
-                            .default(String::from("unknown")),
-                    )
-                    .col(
-                        ColumnDef::new(Column::Version)
-                            .integer()
-                            .not_null()
-                            .default(1i32),
-                    )
-                    .col(
-                        ColumnDef::new(Column::Size)
-                            .big_integer()
-                            .not_null()
-                            .default(0i64),
-                    )
-                    .col(ColumnDef::new(Column::Data).binary())
-                    .to_owned(),
-            )
+            .create_table(schema.create_table_from_entity(Document))
             .await
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Entity).to_owned())
+            .drop_table(Table::drop().table(Document).to_owned())
             .await
     }
 }

--- a/mugen-server/migration/src/main.rs
+++ b/mugen-server/migration/src/main.rs
@@ -1,7 +1,7 @@
 use migration::Migrator;
-use sea_schema::migration::*;
+use sea_orm_migration::prelude::*;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() {
     cli::run_cli(Migrator).await;
 }

--- a/mugen-server/src/config/db.rs
+++ b/mugen-server/src/config/db.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 
+use migration::migrate_database;
 use sea_orm::{ConnectOptions, Database, DatabaseConnection, DbErr};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -15,7 +16,9 @@ pub async fn get_database_connection_pool(config: app::Config) -> Result<Databas
         .idle_timeout(Duration::from_secs(8))
         .sqlx_logging(true);
 
-    Ok(Database::connect(db).await?)
+    let connection = Database::connect(db).await?;
+    migrate_database(&connection).await?;
+    Ok(connection)
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
- Document migration is now based on the Enttity, so this is in sync now
- Migrations are run on database connection, sea orm is aware which migrations are already run so this should be fine
- `sea-orm-migration` crate doesn't depend on `async-std` anymore so I chose tokio as the runtime for migration as we already depend on tokio anyway