### PR TITLE
update seaorm and other dependencies

### DIFF
--- a/mugen-server/Cargo.toml
+++ b/mugen-server/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["koopa1338 <sinner1991@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-axum = "0.5.11"
+axum = "0.5.13"
 dotenv = "0.15.0"
-tokio = { version = "1.19.2", features = ["full"] }
+tokio = { version = "1.20.0", features = ["full"] }
 tokio-util = "0.7.3"
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter", "json", "fmt", "registry"] }
@@ -15,8 +15,8 @@ tracing-attributes = "0.1.22"
 tracing-appender = "0.2.2"
 tower = { version = "0.4.13", features = ["timeout"] }
 tower-http = { version = "0.3.4", features = ["fs", "trace"] }
-serde = { version = "1.0.138", features = ["derive"] }
-sea-orm = { version = "0.8.0", features = [
+serde = { version = "1.0.140", features = ["derive"] }
+sea-orm = { version = "0.9.0", features = [
     "sqlx-postgres",
     "runtime-tokio-native-tls",
     "macros",
@@ -24,7 +24,7 @@ sea-orm = { version = "0.8.0", features = [
     "with-chrono",
 ], default-features = false }
 anyhow = "1.0.58"
-clap = { version = "3.2.8", features = ["derive", "env"] }
+clap = { version = "3.2.13", features = ["derive", "env"] }
 entity = { path = "entity" }
 migration = { path = "migration" }
 toml = "0.5.9"

--- a/mugen-server/entity/Cargo.toml
+++ b/mugen-server/entity/Cargo.toml
@@ -9,14 +9,16 @@ name = "entity"
 path = "src/lib.rs"
 
 [dependencies]
-serde = { version = "1.0.138", features = ["derive"] }
+serde = { version = "1.0.140", features = ["derive"] }
 
 [dependencies.sea-orm]
-version = "0.8.0"
+version = "0.9.0"
 features = [
   "macros",
   "debug-print",
   "runtime-tokio-native-tls",
-  "sqlx-postgres"
+  "sqlx-postgres",
+  "with-chrono",
+  "with-json",
 ]
 default-features = false

--- a/mugen-server/migration/Cargo.toml
+++ b/mugen-server/migration/Cargo.toml
@@ -10,10 +10,10 @@ path = "src/lib.rs"
 
 [dependencies]
 entity = { path = "../entity" }
-sea-orm-migration = { version = "0.8.3", features = [ "runtime-tokio-native-tls", "sqlx-postgres" ] }
-sea-orm = { version = "0.8.0", features = [
+sea-orm-migration = { version = "0.9.0", features = [ "runtime-tokio-native-tls", "sqlx-postgres" ] }
+sea-orm = { version = "0.9.0", features = [
     "sqlx-postgres",
     "runtime-tokio-native-tls",
     "macros",
 ], default-features = false }
-tokio = { version = "1.19.2", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.20.0", features = ["rt-multi-thread", "macros"] }

--- a/mugen-server/migration/src/m20220214_000001_documents.rs
+++ b/mugen-server/migration/src/m20220214_000001_documents.rs
@@ -1,13 +1,8 @@
 use entity::{sea_orm::Schema, document::Entity as Document};
 pub use sea_orm_migration::prelude::*;
 
+#[derive(DeriveMigrationName)]
 pub struct Migration;
-
-impl MigrationName for Migration {
-    fn name(&self) -> &str {
-        "m20220214_000001_documents"
-    }
-}
 
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {

--- a/mugen-server/src/services/docs.rs
+++ b/mugen-server/src/services/docs.rs
@@ -1,5 +1,7 @@
 use entity::document::{ActiveModel, Entity as Document, Model as DocumentModel};
-use sea_orm::{prelude::*, DatabaseConnection, DeleteResult, IntoActiveModel, Set, ActiveValue::NotSet};
+use sea_orm::{
+    prelude::*, ActiveValue::NotSet, DatabaseConnection, DeleteResult, IntoActiveModel, Set,
+};
 use tracing_attributes::instrument;
 
 #[instrument]
@@ -27,7 +29,6 @@ pub async fn create_doc(
     entity.id = NotSet;
 
     entity.insert(conn).await
-
 }
 
 #[instrument]


### PR DESCRIPTION
- Update sea-orm and sea-orm-migration to 0.9
- Use `DeriveMigrationName` trait in migrations
- update features
- formatting