### PR TITLE
failsafe logging with error handling

### DIFF
--- a/mugen-server/src/utils/logging.rs
+++ b/mugen-server/src/utils/logging.rs
@@ -1,13 +1,11 @@
+use anyhow::Result;
+use dotenv::dotenv;
+use serde::Deserialize;
 use std::fmt::Debug;
 use std::fs::{create_dir_all, read_to_string};
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::str::FromStr;
-
-use serde::Deserialize;
-
-use anyhow::Result;
-use dotenv::dotenv;
 use tracing::span::{Attributes, Record};
 use tracing::subscriber::Interest;
 use tracing::{Event, Id, Metadata, Subscriber};
@@ -56,14 +54,23 @@ pub fn init_logging() -> Result<Vec<WorkerGuard>> {
     let mut layers = Vec::new();
     let mut guards = Vec::new();
 
-    let targets = Targets::from_str(&conf.stream_logger.modules.join(","))?;
-    let stream_layer = fmt::Layer::new()
-        .with_writer(std::io::stdout)
-        .with_ansi(conf.stream_logger.color)
-        .with_filter(targets)
-        .boxed();
+    match Targets::from_str(&conf.stream_logger.modules.join(",")) {
+        Ok(targets) => {
+            let stream_layer = fmt::Layer::new()
+                .with_writer(std::io::stdout)
+                .with_ansi(conf.stream_logger.color)
+                .with_filter(targets)
+                .boxed();
 
-    layers.push(stream_layer);
+            layers.push(stream_layer);
+        }
+        Err(error) => {
+            eprintln!(
+                "Error parsing file targets. stdout logging failed to initialize, config has errors: {:#?}",
+                &conf.stream_logger
+            );
+        }
+    }
 
     if let Some(file_logger_table) = conf.file_logger {
         file_logger_table
@@ -72,23 +79,37 @@ pub fn init_logging() -> Result<Vec<WorkerGuard>> {
             .for_each(|entry| {
                 let log_dir = &entry.path;
                 if !log_dir.exists() {
-                    create_dir_all(&log_dir).unwrap();
+                    if let Err(io) = create_dir_all(&log_dir) {
+                        eprintln!("Error creating logging dir {}.", &log_dir.display());
+                        return;
+                    }
                 }
                 let appender = tracing_appender::rolling::never(log_dir, &entry.filename);
                 let (file_writer, guard) = tracing_appender::non_blocking(appender);
                 guards.push(guard);
 
-                let file_targets = Targets::from_str(&entry.modules.join(","))
-                    .unwrap_or_else(|_| panic!("error parsing for {entry:?}"));
-                let file_layer = fmt::Layer::new().with_writer(file_writer).with_ansi(false);
-                let layer = match entry.format {
-                    LogFormat::Full => file_layer.with_filter(file_targets).boxed(),
-                    LogFormat::Compact => file_layer.compact().with_filter(file_targets).boxed(),
-                    LogFormat::Pretty => file_layer.pretty().with_filter(file_targets).boxed(),
-                    LogFormat::Json => file_layer.json().with_filter(file_targets).boxed(),
-                };
+                match Targets::from_str(&entry.modules.join(",")) {
+                    Ok(file_targets) => {
+                        let file_layer =
+                            fmt::Layer::new().with_writer(file_writer).with_ansi(false);
+                        let layer = match entry.format {
+                            LogFormat::Full => file_layer.with_filter(file_targets).boxed(),
+                            LogFormat::Compact => {
+                                file_layer.compact().with_filter(file_targets).boxed()
+                            }
+                            LogFormat::Pretty => {
+                                file_layer.pretty().with_filter(file_targets).boxed()
+                            }
+                            LogFormat::Json => file_layer.json().with_filter(file_targets).boxed(),
+                        };
 
-                layers.push(layer);
+                        layers.push(layer);
+                    }
+                    Err(error) => {
+                        eprintln!("Error parsing file targets. failed to initialize file logging for {:#?}", entry);
+                        return;
+                    }
+                }
             });
     }
     tracing_subscriber::registry().with(layers).init();


### PR DESCRIPTION
If a logger config from `logging.toml` has errors while parsing it is skipped. This way we still have logging for the correct ones. As we have no tracing in the init process we use the `eprintln!` macro as a fallback.