### PR TITLE
improved error handling

### DIFF
--- a/mugen-server/src/config/db.rs
+++ b/mugen-server/src/config/db.rs
@@ -20,26 +20,3 @@ pub async fn get_database_connection_pool(config: app::Config) -> Result<Databas
     migrate_database(&connection).await?;
     Ok(connection)
 }
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct ErrJsonValue {
-    kind: String,
-    message: String,
-}
-
-impl From<DbErr> for ErrJsonValue {
-    fn from(err: DbErr) -> Self {
-        let error: String = err.to_string();
-        if let Some((kind, message)) = error.split_once(": ") {
-            return Self {
-                kind: kind.into(),
-                message: message.into(),
-            };
-        }
-
-        Self {
-            kind: String::from("Unknown"),
-            message: error,
-        }
-    }
-}

--- a/mugen-server/src/error.rs
+++ b/mugen-server/src/error.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use migration::DbErr;
 use std::{error::Error, fmt::Display};
+use tracing::error;
 
 #[derive(Debug)]
 pub enum ApiError {
@@ -40,8 +41,14 @@ impl From<DbErr> for ApiError {
             | DbErr::Custom(msg)
             | DbErr::Type(msg)
             | DbErr::Json(msg)
-            | DbErr::Migration(msg) => Self::Internal(msg),
-            DbErr::RecordNotFound(msg) => Self::NotFound(msg),
+            | DbErr::Migration(msg) => {
+                error!(msg);
+                Self::Internal(msg)
+            }
+            DbErr::RecordNotFound(msg) => {
+                error!(msg);
+                Self::NotFound(msg)
+            }
         }
     }
 }

--- a/mugen-server/src/error.rs
+++ b/mugen-server/src/error.rs
@@ -1,0 +1,62 @@
+use axum::{
+    http::{request::Parts, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use migration::DbErr;
+use std::{error::Error, fmt::Display};
+
+#[derive(Debug)]
+pub enum ApiError {
+    NotFound(String),
+    Internal(String),
+}
+
+impl ApiError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn error_message(&self) -> String {
+        match self {
+            ApiError::NotFound(msg) | ApiError::Internal(msg) => msg.clone(),
+        }
+    }
+
+    fn response(&self) -> (StatusCode, String) {
+        (self.status_code(), self.error_message())
+    }
+}
+
+impl From<DbErr> for ApiError {
+    fn from(err: DbErr) -> Self {
+        match err {
+            DbErr::Conn(msg)
+            | DbErr::Exec(msg)
+            | DbErr::Query(msg)
+            | DbErr::Custom(msg)
+            | DbErr::Type(msg)
+            | DbErr::Json(msg)
+            | DbErr::Migration(msg) => Self::Internal(msg),
+            DbErr::RecordNotFound(msg) => Self::NotFound(msg),
+        }
+    }
+}
+
+impl Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Statuscode: {}", self.status_code())?;
+        writeln!(f, "Body: {:?}", self.error_message())
+    }
+}
+
+impl Error for ApiError {}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        self.response().into_response()
+    }
+}

--- a/mugen-server/src/handler.rs
+++ b/mugen-server/src/handler.rs
@@ -1,0 +1,7 @@
+use crate::error::ApiError;
+use axum::Json;
+
+pub mod docs;
+pub mod error;
+
+type ApiResult<T> = Result<Json<T>, ApiError>;

--- a/mugen-server/src/handler/mod.rs
+++ b/mugen-server/src/handler/mod.rs
@@ -1,2 +1,0 @@
-pub mod docs;
-pub mod error;

--- a/mugen-server/src/main.rs
+++ b/mugen-server/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(unused_imports, dead_code, unused_variables)]
 
 mod config;
+mod error;
 mod handler;
 mod services;
 mod utils;


### PR DESCRIPTION
use a single error type for api that is used in all handlers. Dont leak any error information to the frontend